### PR TITLE
feat: add loading spinner

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,6 +14,7 @@ const searchBtn = document.getElementById("search-btn") // the search button
 const movieList = document.getElementById("movie-list") // container where results render
 const initialIcon = document.getElementById("initial-icon") // empty-state icon wrapper
 const inputEl = document.getElementById("input-field") // the search <input>
+const spinner = document.getElementById("spinner") //spinner
 
 
 /* =========================
@@ -117,9 +118,17 @@ async function fetchMovieDetails(imdbID) {
           .join("")
         }
 
+        function showSpinner() {
+          spinner.classList.remove("hidden")
+          movieList.innerHTML = ""
+        }
+
+        function hideSpinner() {
+          spinner.classList.add("hidden")
+        }
+
 
         // Error function
-
         function showError(container, message) {
           container.innerHTML = `
             <div class="unable-text-wrapper">
@@ -134,7 +143,8 @@ async function fetchMovieDetails(imdbID) {
 // ============================================================
 const STORAGE_KEY = "watchlist"
 
-// Small helpers to read/write localStorage cleanly 
+// Small helpers to read/write localStorage cleanly
+
 // "reads from localStorage"
 const getWatchlist = () =>
   JSON.parse(localStorage.getItem(STORAGE_KEY) || "[]")
@@ -164,12 +174,15 @@ if (searchBtn && movieList && inputEl) {
     // Clear previous results
     movieList.innerHTML = ""
 
+    showSpinner()
+
     try {
        // Await the search
       const movies = await fetchMovies(query)
 
       // showError function
       if (!movies) {
+        hideSpinner()
         showError(movieList, "Unable to find what you're looking for. Please try another search.")
         return
       }
@@ -179,10 +192,12 @@ if (searchBtn && movieList && inputEl) {
         movies.map(movie => fetchMovieDetails(movie.imdbID))
       )).filter(Boolean) // clean final array
 
+      hideSpinner()
       renderMovies(detailsArray)
 
     } catch (err) {
       console.log("Search failed:", err)
+      hideSpinner()
       showError(movieList, "Something went wrong. Please try again.")
     }
   })

--- a/css/style.css
+++ b/css/style.css
@@ -204,3 +204,29 @@ a {
   font-weight: 700;
   color: #dfdddd;
 }
+
+/* loading spinner */
+
+.spinner-circle {
+  width: 50px;
+  height: 50px;
+  border: 5px solid #ccc;
+  border-top-color: #e44d26;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+#spinner {
+  display: flex;
+  justify-content: center;
+}
+
+#spinner.hidden {
+  display: none;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/index.html
+++ b/index.html
@@ -34,6 +34,11 @@
           class="icon"
         />
       </div>
+
+      <div id="spinner" class="hidden">
+        <div class="spinner-circle"></div>
+      </div>
+      
       <div class="movie-list" id="movie-list"></div>
     </main>
     <script src="/app.js"></script>


### PR DESCRIPTION
## Add loading spinner to search results

Closes #9 

### What changed
- Added `#spinner` HTML element to the results area
- Added CSS spin animation with `@keyframes` and centered it inside the results area
- Added `showSpinner()` and `hideSpinner()` helpers in JS
- Spinner shows on search start, hides on success, error, and empty results
- Fixed CSS specificity conflict between `#spinner { display: flex }` and `.hidden { display: none }` using `#spinner.hidden`

### How to test
1. Open the search page
2. Throttle network to Slow 3G in DevTools
3. Type any movie title and click Search
4. Spinner should appear, then disappear when results load