### PR TITLE
ref: implement is-added button state

### DIFF
--- a/app.js
+++ b/app.js
@@ -51,7 +51,7 @@ async function fetchMovieDetails(imdbID) {
    ========================= */
 
 //Take one movie object, return its HTML
-        function createMovieCard(movie) {
+        function createMovieCard(movie, isAdded) {
           const poster = (movie.Poster && movie.Poster !== "N/A")
             ? movie.Poster
             : "https://placehold.co/300x450?text=No+Poster"
@@ -72,11 +72,12 @@ async function fetchMovieDetails(imdbID) {
                         <p>${movie.Genre}</p>
                       <!-- The button carries the data we want to save in data-* attributes -->
                         <button
-                          class="btn-add"
+                          class="btn-add ${isAdded ? 'is-added' : ''}"
                           data-id="${movie.imdbID}"
                           data-title="${movie.Title}"
                           data-poster="${movie.Poster}"
-                        >+</button>
+                          ${isAdded ? 'disabled' : ''}
+                        >${isAdded ? '✓' : '+'}</button>
                         <p class="btn-add-text">Watchlist</p>
                     </div>
                       <p>${movie.Plot}</p>
@@ -113,8 +114,13 @@ async function fetchMovieDetails(imdbID) {
         }
 
         function renderMovies(detailsArray) {
+          const watchlist = getWatchlist()
+
           movieList.innerHTML = detailsArray
-          .map(movie => createMovieCard(movie))
+          .map(movie => {
+            const isAdded = watchlist.some(m => m.imdbID === movie.imdbID)
+            return createMovieCard(movie, isAdded)
+          })
           .join("")
         }
 
@@ -238,8 +244,13 @@ function addToWatchlist(btn) {
 document.addEventListener("click", (e) => {
   const btn = e.target.closest(".btn-add")
   if (!btn) return // ignore clicks that aren’t on an Add button
+  if (btn.disabled) return //ignore clicks on already-added btn
 
   addToWatchlist(btn)
+
+  btn.textContent = "✓"
+  btn.disabled = true
+  btn.classList.add("is-added")
 })
 
 

--- a/css/style.css
+++ b/css/style.css
@@ -182,6 +182,12 @@ a {
   transform: translate(-50%, -50%) rotate(90deg);
 }
 
+.btn-add.is-added {
+  background: gray;
+  opacity: 0.6;
+  cursor: default;
+}
+
 .btn-add-text {
   font-family: inherit;
   font-size: 12px;


### PR DESCRIPTION
## #14 — Already Added Button State

### What was the problem?
The Add button always rendered as `+` regardless of whether the movie was already saved. After a page refresh, previously added movies showed an active button and allowed duplicates.

### What changed?

**`createMovieCard(movie, isAdded)`**
Added a second parameter `isAdded`. When `true`, the button renders with the `is-added` class, `disabled` attribute, and `✓` text.

**`renderMovies(detailsArray)`**
Now reads localStorage once before mapping over results. Passes `isAdded` into each `createMovieCard` call so the correct button state renders on load.

**Click listener**
After a successful add, the clicked button is mutated directly — text swaps to `✓`, disabled, and `is-added` class applied — no re-render needed.

### Tested
- [x] Add a movie, refresh, search again — button shows as already added
- [x] Add button cannot be clicked twice
- [x] Fresh movies (not in watchlist) still render with active `+` button